### PR TITLE
[BB-1780] Bump `html-xblock` version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,4 @@ django-statici18n==1.8.0
 edx-i18n-tools==0.4.7
 Mako==1.0.7
 bleach==2.1.4
-html-xblock==0.1
+html-xblock==0.1.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='completable-html-xblock',
-    version='0.1',
+    version='0.1.1',
     description='HTML XBlock will help creating and using a secure, easy-to-use and completable HTML blocks',
     license='AGPL v3',
     packages=[
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'XBlock',
         'bleach',
-        'html-xblock',
+        'html-xblock==0.1.1',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
This adds substituting keywords, which was introduced in open-craft/xblock-html#8.

Merging as a trivial version bump.