### PR TITLE
[BB-4011] Koa upgrade: bump Python version for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &DEFAULT
   working_directory: /home/circleci/xblock-html
   docker:
-    - image: circleci/python:3.5
+    - image: circleci/python:3.8
 
 
 version: 2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install https://github.com/open-craft/xblock-html-completable
 ```
 You may specify the `-e` flag if you intend to develop on the repo.
 
-Note that as of version 1.0.0, Python 2.7 is no longer supported. The current minimum Python version is 3.5.
+Note that as of version 1.0.0, Python 2.7 is no longer supported. The current minimum Python version is 3.8.
 
 To enable this block type, add `completable_html5` to course's advanced module list.
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'XBlock',
         'bleach',
-        'html-xblock~=1.0.0', # TODO: Bumpt the minor once it's pushed to PyPi.
+        'html-xblock~=1.1.0',
     ],
     entry_points={
         'xblock.v1': [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name='completable-html-xblock',
-    version='1.0.0',
+    version='1.1.0',
     description='HTML XBlock will help creating and using a secure, easy-to-use and completable HTML blocks',
     license='AGPL v3',
     packages=[
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'XBlock',
         'bleach',
-        'html-xblock~=1.0.0',
+        'html-xblock~=1.0.0', # TODO: Bumpt the minor once it's pushed to PyPi.
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
The Koa release uses Python 3.8, so we should be using this Python version for the CI from now on.

### Testing instructions
1. Check that the CI is passing.