### PR TITLE
fix: remove redundant dependencies [BB-6151]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &DEFAULT
-  working_directory: /home/circleci/xblock-html
+  working_directory: /home/circleci/xblock-html-completable
   docker:
-    - image: circleci/python:3.8
+    - image: cimg/python:3.8
 
 
 version: 2

--- a/Makefile
+++ b/Makefile
@@ -33,23 +33,21 @@ test_requirements: base_requirements ## Install requirements needed by test envi
 	pip install -q -r requirements/test.txt --exists-action w
 
 requirements: base_requirements test_requirements ## Installs all requirements needed by developmenent and test environments
-	pip install -e .
 	@echo "Finished installing requirements."
 
 quality:  ## Run quality tests and checks
 	make selfcheck
 	pylint completable_html_xblock tests
-	pylint --py3k completable_html_xblock
 	pycodestyle completable_html_xblock tests --config=pylintrc
 	pydocstyle completable_html_xblock tests --config=pylintrc
-	isort --check-only --diff --recursive tests completable_html_xblock
+	isort --check-only --diff tests completable_html_xblock
 
 unit-coverage: clean ## Run coverage and unit tests
 	mkdir var/
 	coverage run ./manage.py test
 	coverage html
 	coverage xml
-	diff-cover coverage.xml --html-report diff-cover.html
+	diff-cover --compare-branch origin/master coverage.xml --html-report diff-cover.html
 
 unit: clean ## Run unit tests
 	mkdir var/

--- a/completable_html_xblock/html.py
+++ b/completable_html_xblock/html.py
@@ -54,7 +54,7 @@ class CompletableHTML5XBlock(CompletableXBlockMixin, HTML5XBlock):
         """
         Return a fragment that contains the html for the student view. Add #complete element.
         """
-        frag = super(CompletableHTML5XBlock, self).student_view()
+        frag = super().student_view()
         frag.add_javascript(self.completable_resource_string('static/js/html_completion.js'))
         frag.initialize_js('HTML5CompletionXBlock')
 

--- a/pylintrc
+++ b/pylintrc
@@ -36,5 +36,4 @@ min-similarity-lines=8
 ignore=D101,D400,D401,D200,D203,D205,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
 
 [pycodestyle]
-exclude = .git,migrations
 max-line-length=120

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,4 @@
 # Requirements for app run
 
-git+https://github.com/edx/xblock-utils.git@2.1.1#egg=xblock-utils==2.1.1
-django-statici18n==1.9.0
-edx-i18n-tools==0.5.3
-Mako==1.1.3
-bleach==3.1.5
-html-xblock~=1.0.0
-django~=2.2
+xblock-utils==2.2.0
+html-xblock>=1.0.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -1,9 +1,7 @@
 # Requirements for code quality checks
 
-isort==4.3.21
-astroid==2.3.3
-pycodestyle==2.6.0
-pydocstyle==5.0.2
-pylint==2.4.2
-caniusepython3==7.2.0
-edx-lint==1.4.1
+isort==5.10.1
+pycodestyle==2.9.1
+pydocstyle==6.1.1
+pylint==2.14.5
+edx-lint==5.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,14 +1,14 @@
 # Requirements for test runs
 
-codecov==2.0.15
-diff-cover==2.6.1
-django-nose==1.4.4
+codecov==2.1.12
+diff-cover==6.5.1
+django-nose==1.4.7
 lazy==1.4
-pytest-cov==2.8.1
-tox==3.15.0
-tox-battery==0.6.0
-mock==3.0.5
+pytest-cov==3.0.0
+tox==3.25.1
+tox-battery==0.6.1
+mock==4.0.3
 
-# Github requirements
-git+https://github.com/edx/django-pyfs.git@2.1#egg=django-pyfs==2.1
-xblock-sdk
+# Open edX requiements
+django-pyfs==3.1.0
+xblock-sdk==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -23,21 +23,19 @@ def package_data(pkg, roots):
 
 setup(
     name='completable-html-xblock',
-    version='1.2.0',
+    version='1.2.1',
     description='HTML XBlock will help creating and using a secure, easy-to-use and completable HTML blocks',
     license='AGPL v3',
     packages=[
         'completable_html_xblock',
     ],
     install_requires=[
-        'XBlock',
-        'bleach',
-        'html-xblock~=1.2.0',
+        'html-xblock>=1.0.0',
     ],
     entry_points={
         'xblock.v1': [
             'completable_html5 = completable_html_xblock:CompletableHTML5XBlock',
         ]
     },
-    package_data=package_data("completable_html_xblock", ["static", "public"]),
+    package_data=package_data("completable_html_xblock", ["static", "translations"]),
 )


### PR DESCRIPTION
This XBlock does not depend on any version of `xblock-html` newer than v1.0.0.
Therefore, we don't need a strict version pin for it.
This also updates test dependencies to fix the CI.